### PR TITLE
chore(dep): Remove unused dependency `notation` in `Permission.ts`

### DIFF
--- a/src/core/Permission.ts
+++ b/src/core/Permission.ts
@@ -1,5 +1,3 @@
-// dep modules
-import * as Notation from 'notation';
 // own modules
 import { IQueryInfo } from '../core';
 import utils from '../utils';


### PR DESCRIPTION
I don't know if this is proper, just notice that you have nothing to do with `notation` in this file
: P